### PR TITLE
Resize the devices list before calling vkEnumeratePhysicalDevices second time

### DIFF
--- a/chapter01/03_vulkan_window/window/Window.cpp
+++ b/chapter01/03_vulkan_window/window/Window.cpp
@@ -88,6 +88,7 @@ bool Window::initVulkan() {
   }
 
   std::vector<VkPhysicalDevice> devices;
+  devices.resize(physicalDeviceCount);
   vkEnumeratePhysicalDevices(mInstance, &physicalDeviceCount, devices.data());
 
   Logger::log(1, "%s: Found %u physical device(s)\n", __FUNCTION__, physicalDeviceCount);


### PR DESCRIPTION
Without resizing the vector we can end up with undefined behaviour because the size of the vector can be less than the number of devices