### PR TITLE
Move fence reset to avoid hanging on resize, fix sRGB color problems

### DIFF
--- a/chapter02/opengl_renderer/opengl/Framebuffer.cpp
+++ b/chapter02/opengl_renderer/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter02/opengl_renderer/opengl/Texture.cpp
+++ b/chapter02/opengl_renderer/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter03/vulkan_renderer/vulkan/VkRenderer.cpp
+++ b/chapter03/vulkan_renderer/vulkan/VkRenderer.cpp
@@ -176,10 +176,20 @@ bool VkRenderer::createDepthBuffer() {
 }
 
 bool VkRenderer::createSwapchain() {
-   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -367,11 +377,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error: fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -387,6 +392,11 @@ bool VkRenderer::draw() {
         Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
         return false;
       }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error: fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {

--- a/chapter04/01_opengl_shader_switch/opengl/Framebuffer.cpp
+++ b/chapter04/01_opengl_shader_switch/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter04/01_opengl_shader_switch/opengl/Texture.cpp
+++ b/chapter04/01_opengl_shader_switch/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter04/02_opengl_ubo/opengl/Framebuffer.cpp
+++ b/chapter04/02_opengl_ubo/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter04/02_opengl_ubo/opengl/Texture.cpp
+++ b/chapter04/02_opengl_ubo/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter04/03_vulkan_shader_switch/vulkan/VkRenderer.cpp
+++ b/chapter04/03_vulkan_shader_switch/vulkan/VkRenderer.cpp
@@ -189,10 +189,20 @@ bool VkRenderer::createDepthBuffer() {
 }
 
 bool VkRenderer::createSwapchain() {
-   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -403,11 +413,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -423,6 +428,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {

--- a/chapter04/04_vulkan_ubo/vulkan/VkRenderer.cpp
+++ b/chapter04/04_vulkan_ubo/vulkan/VkRenderer.cpp
@@ -197,10 +197,20 @@ bool VkRenderer::createDepthBuffer() {
 }
 
 bool VkRenderer::createSwapchain() {
-   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -423,11 +433,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -443,6 +448,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {

--- a/chapter04/05_vulkan_push_constant/vulkan/VkRenderer.cpp
+++ b/chapter04/05_vulkan_push_constant/vulkan/VkRenderer.cpp
@@ -186,9 +186,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -402,11 +412,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -422,6 +427,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {

--- a/chapter05/01_opengl_ui/opengl/Framebuffer.cpp
+++ b/chapter05/01_opengl_ui/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter05/01_opengl_ui/opengl/Texture.cpp
+++ b/chapter05/01_opengl_ui/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter05/02_opengl_ui_fps/opengl/Framebuffer.cpp
+++ b/chapter05/02_opengl_ui_fps/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter05/02_opengl_ui_fps/opengl/Texture.cpp
+++ b/chapter05/02_opengl_ui_fps/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter05/03_opengl_ui_timer/opengl/Framebuffer.cpp
+++ b/chapter05/03_opengl_ui_timer/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter05/03_opengl_ui_timer/opengl/Texture.cpp
+++ b/chapter05/03_opengl_ui_timer/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter05/04_opengl_ui_controls/opengl/Framebuffer.cpp
+++ b/chapter05/04_opengl_ui_controls/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter05/04_opengl_ui_controls/opengl/Texture.cpp
+++ b/chapter05/04_opengl_ui_controls/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter05/05_vulkan_ui/vulkan/VkRenderer.cpp
+++ b/chapter05/05_vulkan_ui/vulkan/VkRenderer.cpp
@@ -205,9 +205,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -441,11 +451,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -463,6 +468,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter05/06_vulkan_ui_fps/vulkan/VkRenderer.cpp
+++ b/chapter05/06_vulkan_ui_fps/vulkan/VkRenderer.cpp
@@ -205,9 +205,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -444,11 +454,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -466,6 +471,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter05/07_vulkan_ui_timer/vulkan/VkRenderer.cpp
+++ b/chapter05/07_vulkan_ui_timer/vulkan/VkRenderer.cpp
@@ -207,9 +207,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -446,11 +456,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -468,6 +473,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter05/08_vulkan_ui_controls/vulkan/VkRenderer.cpp
+++ b/chapter05/08_vulkan_ui_controls/vulkan/VkRenderer.cpp
@@ -207,9 +207,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -446,11 +456,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -468,6 +473,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter06/01_opengl_view/opengl/Framebuffer.cpp
+++ b/chapter06/01_opengl_view/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter06/01_opengl_view/opengl/Texture.cpp
+++ b/chapter06/01_opengl_view/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter06/02_opengl_movement/opengl/Framebuffer.cpp
+++ b/chapter06/02_opengl_movement/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter06/02_opengl_movement/opengl/Texture.cpp
+++ b/chapter06/02_opengl_movement/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter06/03_vulkan_view/vulkan/VkRenderer.cpp
+++ b/chapter06/03_vulkan_view/vulkan/VkRenderer.cpp
@@ -208,9 +208,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -513,11 +523,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -535,6 +540,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter06/04_vulkan_movement/vulkan/VkRenderer.cpp
+++ b/chapter06/04_vulkan_movement/vulkan/VkRenderer.cpp
@@ -208,9 +208,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -550,11 +560,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -572,6 +577,10 @@ bool VkRenderer::draw() {
     }
   }
 
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
+  }
 
   if (vkResetCommandBuffer(mRenderData.rdCommandBuffer, 0) != VK_SUCCESS) {
     Logger::log(1, "%s error: failed to reset command buffer\n", __FUNCTION__);

--- a/chapter07/01_opengl_rotation/opengl/Framebuffer.cpp
+++ b/chapter07/01_opengl_rotation/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/01_opengl_rotation/opengl/OGLRenderer.cpp
+++ b/chapter07/01_opengl_rotation/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/01_opengl_rotation/opengl/Texture.cpp
+++ b/chapter07/01_opengl_rotation/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/02_opengl_quaternion/opengl/Framebuffer.cpp
+++ b/chapter07/02_opengl_quaternion/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/02_opengl_quaternion/opengl/OGLRenderer.cpp
+++ b/chapter07/02_opengl_quaternion/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/02_opengl_quaternion/opengl/Texture.cpp
+++ b/chapter07/02_opengl_quaternion/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/03_opengl_relative_rotation/opengl/Framebuffer.cpp
+++ b/chapter07/03_opengl_relative_rotation/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/03_opengl_relative_rotation/opengl/OGLRenderer.cpp
+++ b/chapter07/03_opengl_relative_rotation/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/03_opengl_relative_rotation/opengl/Texture.cpp
+++ b/chapter07/03_opengl_relative_rotation/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/04_opengl_slerp/opengl/Framebuffer.cpp
+++ b/chapter07/04_opengl_slerp/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/04_opengl_slerp/opengl/OGLRenderer.cpp
+++ b/chapter07/04_opengl_slerp/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/04_opengl_slerp/opengl/Texture.cpp
+++ b/chapter07/04_opengl_slerp/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/05_opengl_spline/opengl/Framebuffer.cpp
+++ b/chapter07/05_opengl_spline/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/05_opengl_spline/opengl/OGLRenderer.cpp
+++ b/chapter07/05_opengl_spline/opengl/OGLRenderer.cpp
@@ -69,6 +69,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/05_opengl_spline/opengl/Texture.cpp
+++ b/chapter07/05_opengl_spline/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/06_opengl_quat_spline/opengl/Framebuffer.cpp
+++ b/chapter07/06_opengl_quat_spline/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/06_opengl_quat_spline/opengl/OGLRenderer.cpp
+++ b/chapter07/06_opengl_quat_spline/opengl/OGLRenderer.cpp
@@ -69,6 +69,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mModelMesh = std::make_unique<OGLMesh>();

--- a/chapter07/06_opengl_quat_spline/opengl/Texture.cpp
+++ b/chapter07/06_opengl_quat_spline/opengl/Texture.cpp
@@ -28,7 +28,7 @@ bool Texture::loadTexture(std::string textureFilename) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter07/08_vulkan_quaternion/vulkan/VkRenderer.cpp
+++ b/chapter07/08_vulkan_quaternion/vulkan/VkRenderer.cpp
@@ -229,9 +229,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -555,11 +565,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -575,6 +580,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter07/09_vulkan_relative_rotation/vulkan/VkRenderer.cpp
+++ b/chapter07/09_vulkan_relative_rotation/vulkan/VkRenderer.cpp
@@ -229,9 +229,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -555,11 +565,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -575,6 +580,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter07/11_vulkan_spline/vulkan/VkRenderer.cpp
+++ b/chapter07/11_vulkan_spline/vulkan/VkRenderer.cpp
@@ -229,9 +229,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -555,11 +565,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -575,6 +580,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter07/12_vulkan_quat_spline/vulkan/VkRenderer.cpp
+++ b/chapter07/12_vulkan_quat_spline/vulkan/VkRenderer.cpp
@@ -229,9 +229,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -555,11 +565,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -575,6 +580,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter08/01_opengl_gltf_load/opengl/Framebuffer.cpp
+++ b/chapter08/01_opengl_gltf_load/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter08/01_opengl_gltf_load/opengl/OGLRenderer.cpp
+++ b/chapter08/01_opengl_gltf_load/opengl/OGLRenderer.cpp
@@ -72,6 +72,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter08/01_opengl_gltf_load/opengl/Texture.cpp
+++ b/chapter08/01_opengl_gltf_load/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter08/02_vulkan_gltf_load/vulkan/VkRenderer.cpp
+++ b/chapter08/02_vulkan_gltf_load/vulkan/VkRenderer.cpp
@@ -242,9 +242,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -609,11 +619,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -629,6 +634,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter09/01_opengl_gltf_bindpose/opengl/Framebuffer.cpp
+++ b/chapter09/01_opengl_gltf_bindpose/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter09/01_opengl_gltf_bindpose/opengl/OGLRenderer.cpp
+++ b/chapter09/01_opengl_gltf_bindpose/opengl/OGLRenderer.cpp
@@ -72,6 +72,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter09/01_opengl_gltf_bindpose/opengl/Texture.cpp
+++ b/chapter09/01_opengl_gltf_bindpose/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter09/02_opengl_gltf_gpu_skinning/opengl/Framebuffer.cpp
+++ b/chapter09/02_opengl_gltf_gpu_skinning/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter09/02_opengl_gltf_gpu_skinning/opengl/OGLRenderer.cpp
+++ b/chapter09/02_opengl_gltf_gpu_skinning/opengl/OGLRenderer.cpp
@@ -77,6 +77,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter09/02_opengl_gltf_gpu_skinning/opengl/Texture.cpp
+++ b/chapter09/02_opengl_gltf_gpu_skinning/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter09/03_opengl_gltf_ssbo/opengl/Framebuffer.cpp
+++ b/chapter09/03_opengl_gltf_ssbo/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter09/03_opengl_gltf_ssbo/opengl/OGLRenderer.cpp
+++ b/chapter09/03_opengl_gltf_ssbo/opengl/OGLRenderer.cpp
@@ -77,6 +77,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter09/03_opengl_gltf_ssbo/opengl/Texture.cpp
+++ b/chapter09/03_opengl_gltf_ssbo/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter09/04_opengl_gltf_dual_quat/opengl/Framebuffer.cpp
+++ b/chapter09/04_opengl_gltf_dual_quat/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter09/04_opengl_gltf_dual_quat/opengl/OGLRenderer.cpp
+++ b/chapter09/04_opengl_gltf_dual_quat/opengl/OGLRenderer.cpp
@@ -82,6 +82,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mModel = std::make_unique<Model>();
 
   mEulerModelMesh = std::make_unique<OGLMesh>();

--- a/chapter09/04_opengl_gltf_dual_quat/opengl/Texture.cpp
+++ b/chapter09/04_opengl_gltf_dual_quat/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter09/05_vulkan_gltf_bindpose/vulkan/VkRenderer.cpp
+++ b/chapter09/05_vulkan_gltf_bindpose/vulkan/VkRenderer.cpp
@@ -250,9 +250,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -630,11 +640,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -650,6 +655,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter09/06_vulkan_gltf_gpu_skinning/vulkan/VkRenderer.cpp
+++ b/chapter09/06_vulkan_gltf_gpu_skinning/vulkan/VkRenderer.cpp
@@ -253,9 +253,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -649,11 +659,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -669,6 +674,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter09/07_vulkan_gltf_ssbo/vulkan/VkRenderer.cpp
+++ b/chapter09/07_vulkan_gltf_ssbo/vulkan/VkRenderer.cpp
@@ -252,9 +252,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -648,11 +658,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -668,6 +673,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter09/08_vulkan_gltf_dual_quat/vulkan/VkRenderer.cpp
+++ b/chapter09/08_vulkan_gltf_dual_quat/vulkan/VkRenderer.cpp
@@ -257,9 +257,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -666,11 +676,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -686,6 +691,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter10/01_opengl_animations/opengl/Framebuffer.cpp
+++ b/chapter10/01_opengl_animations/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter10/01_opengl_animations/opengl/OGLRenderer.cpp
+++ b/chapter10/01_opengl_animations/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter10/01_opengl_animations/opengl/Texture.cpp
+++ b/chapter10/01_opengl_animations/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter10/02_vulkan_animations/vulkan/VkRenderer.cpp
+++ b/chapter10/02_vulkan_animations/vulkan/VkRenderer.cpp
@@ -239,9 +239,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -622,11 +632,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -642,6 +647,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter11/01_opengl_blending/opengl/Framebuffer.cpp
+++ b/chapter11/01_opengl_blending/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter11/01_opengl_blending/opengl/OGLRenderer.cpp
+++ b/chapter11/01_opengl_blending/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter11/01_opengl_blending/opengl/Texture.cpp
+++ b/chapter11/01_opengl_blending/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter11/02_opengl_crossblending/opengl/Framebuffer.cpp
+++ b/chapter11/02_opengl_crossblending/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter11/02_opengl_crossblending/opengl/OGLRenderer.cpp
+++ b/chapter11/02_opengl_crossblending/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter11/02_opengl_crossblending/opengl/Texture.cpp
+++ b/chapter11/02_opengl_crossblending/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter11/03_opengl_additive_blending/opengl/Framebuffer.cpp
+++ b/chapter11/03_opengl_additive_blending/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter11/03_opengl_additive_blending/opengl/OGLRenderer.cpp
+++ b/chapter11/03_opengl_additive_blending/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter11/03_opengl_additive_blending/opengl/Texture.cpp
+++ b/chapter11/03_opengl_additive_blending/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter11/04_vulkan_blending/vulkan/VkRenderer.cpp
+++ b/chapter11/04_vulkan_blending/vulkan/VkRenderer.cpp
@@ -239,9 +239,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -622,11 +632,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -642,6 +647,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter11/05_vulkan_crossblending/vulkan/VkRenderer.cpp
+++ b/chapter11/05_vulkan_crossblending/vulkan/VkRenderer.cpp
@@ -239,9 +239,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -622,11 +632,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -642,6 +647,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter11/06_vulkan_additive_blending/vulkan/VkRenderer.cpp
+++ b/chapter11/06_vulkan_additive_blending/vulkan/VkRenderer.cpp
@@ -242,9 +242,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -625,11 +635,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -645,6 +650,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter12/01_opengl_combobox/opengl/Framebuffer.cpp
+++ b/chapter12/01_opengl_combobox/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter12/01_opengl_combobox/opengl/OGLRenderer.cpp
+++ b/chapter12/01_opengl_combobox/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter12/01_opengl_combobox/opengl/Texture.cpp
+++ b/chapter12/01_opengl_combobox/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter12/02_opengl_radiobutton/opengl/Framebuffer.cpp
+++ b/chapter12/02_opengl_radiobutton/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter12/02_opengl_radiobutton/opengl/OGLRenderer.cpp
+++ b/chapter12/02_opengl_radiobutton/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter12/02_opengl_radiobutton/opengl/Texture.cpp
+++ b/chapter12/02_opengl_radiobutton/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter12/03_opengl_plots/opengl/Framebuffer.cpp
+++ b/chapter12/03_opengl_plots/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter12/03_opengl_plots/opengl/OGLRenderer.cpp
+++ b/chapter12/03_opengl_plots/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter12/03_opengl_plots/opengl/Texture.cpp
+++ b/chapter12/03_opengl_plots/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter12/04_vulkan_combobox/vulkan/VkRenderer.cpp
+++ b/chapter12/04_vulkan_combobox/vulkan/VkRenderer.cpp
@@ -242,9 +242,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -625,11 +635,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -645,6 +650,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter12/05_vulkan_radiobutton/vulkan/VkRenderer.cpp
+++ b/chapter12/05_vulkan_radiobutton/vulkan/VkRenderer.cpp
@@ -242,9 +242,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -625,11 +635,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -645,6 +650,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter12/06_vulkan_plots/vulkan/VkRenderer.cpp
+++ b/chapter12/06_vulkan_plots/vulkan/VkRenderer.cpp
@@ -242,9 +242,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -625,11 +635,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -645,6 +650,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter13/01_opengl_ccd/opengl/Framebuffer.cpp
+++ b/chapter13/01_opengl_ccd/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter13/01_opengl_ccd/opengl/OGLRenderer.cpp
+++ b/chapter13/01_opengl_ccd/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter13/01_opengl_ccd/opengl/Texture.cpp
+++ b/chapter13/01_opengl_ccd/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter13/02_opengl_fabrik/opengl/Framebuffer.cpp
+++ b/chapter13/02_opengl_fabrik/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter13/02_opengl_fabrik/opengl/OGLRenderer.cpp
+++ b/chapter13/02_opengl_fabrik/opengl/OGLRenderer.cpp
@@ -68,6 +68,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter13/02_opengl_fabrik/opengl/Texture.cpp
+++ b/chapter13/02_opengl_fabrik/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter13/03_vulkan_ccd/vulkan/VkRenderer.cpp
+++ b/chapter13/03_vulkan_ccd/vulkan/VkRenderer.cpp
@@ -250,9 +250,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -633,11 +643,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -653,6 +658,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter13/04_vulkan_fabrik/vulkan/VkRenderer.cpp
+++ b/chapter13/04_vulkan_fabrik/vulkan/VkRenderer.cpp
@@ -250,9 +250,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -633,11 +643,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -653,6 +658,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter14/01_opengl_instances/opengl/Framebuffer.cpp
+++ b/chapter14/01_opengl_instances/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter14/01_opengl_instances/opengl/OGLRenderer.cpp
+++ b/chapter14/01_opengl_instances/opengl/OGLRenderer.cpp
@@ -87,6 +87,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter14/01_opengl_instances/opengl/Texture.cpp
+++ b/chapter14/01_opengl_instances/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter14/02_opengl_multiple_models/opengl/Framebuffer.cpp
+++ b/chapter14/02_opengl_multiple_models/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter14/02_opengl_multiple_models/opengl/OGLRenderer.cpp
+++ b/chapter14/02_opengl_multiple_models/opengl/OGLRenderer.cpp
@@ -87,7 +87,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
-  /* load 2x the woman and the sq model */
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
+  /* load 2x the woman and the dq model */
   mGltfModels.resize(3);
   mGltfModels.at(0) = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";

--- a/chapter14/02_opengl_multiple_models/opengl/Texture.cpp
+++ b/chapter14/02_opengl_multiple_models/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter14/03_opengl_instanced_drawing/opengl/Framebuffer.cpp
+++ b/chapter14/03_opengl_instanced_drawing/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter14/03_opengl_instanced_drawing/opengl/OGLRenderer.cpp
+++ b/chapter14/03_opengl_instanced_drawing/opengl/OGLRenderer.cpp
@@ -87,6 +87,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter14/03_opengl_instanced_drawing/opengl/Texture.cpp
+++ b/chapter14/03_opengl_instanced_drawing/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter14/04_opengl_tbo/opengl/Framebuffer.cpp
+++ b/chapter14/04_opengl_tbo/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter14/04_opengl_tbo/opengl/OGLRenderer.cpp
+++ b/chapter14/04_opengl_tbo/opengl/OGLRenderer.cpp
@@ -87,6 +87,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter14/04_opengl_tbo/opengl/Texture.cpp
+++ b/chapter14/04_opengl_tbo/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter14/05_vulkan_instances/vulkan/VkRenderer.cpp
+++ b/chapter14/05_vulkan_instances/vulkan/VkRenderer.cpp
@@ -249,9 +249,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -660,11 +670,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -680,6 +685,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter14/06_vulkan_multiple_models/vulkan/VkRenderer.cpp
+++ b/chapter14/06_vulkan_multiple_models/vulkan/VkRenderer.cpp
@@ -250,9 +250,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -701,11 +711,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -721,6 +726,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter14/07_vulkan_instanced_drawing/vulkan/VkRenderer.cpp
+++ b/chapter14/07_vulkan_instanced_drawing/vulkan/VkRenderer.cpp
@@ -249,9 +249,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -658,11 +668,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -678,6 +683,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter14/08_vulkan_tbo/vulkan/VkRenderer.cpp
+++ b/chapter14/08_vulkan_tbo/vulkan/VkRenderer.cpp
@@ -249,9 +249,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -656,11 +666,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -676,6 +681,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;

--- a/chapter15/01_opengl_optimize/opengl/Framebuffer.cpp
+++ b/chapter15/01_opengl_optimize/opengl/Framebuffer.cpp
@@ -7,12 +7,11 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
 
   glGenFramebuffers(1, &mBuffer);
   glBindFramebuffer(GL_FRAMEBUFFER, mBuffer);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter15/01_opengl_optimize/opengl/OGLRenderer.cpp
+++ b/chapter15/01_opengl_optimize/opengl/OGLRenderer.cpp
@@ -87,6 +87,9 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
 
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   mGltfModel = std::make_shared<GltfModel>();
   std::string modelFilename = "assets/Woman.gltf";
   std::string modelTexFilename = "textures/Woman.png";

--- a/chapter15/01_opengl_optimize/opengl/Texture.cpp
+++ b/chapter15/01_opengl_optimize/opengl/Texture.cpp
@@ -27,7 +27,7 @@ bool Texture::loadTexture(std::string textureFilename, bool flipImage) {
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mTexWidth, mTexHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
   glGenerateMipmap(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/chapter15/02_vulkan_optimize/vulkan/VkRenderer.cpp
+++ b/chapter15/02_vulkan_optimize/vulkan/VkRenderer.cpp
@@ -249,9 +249,19 @@ bool VkRenderer::createDepthBuffer() {
 
 bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
+  VkSurfaceFormatKHR surfaceFormat;
+
+  /* set surface to non-sRGB */
+  surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
-  auto  swapChainBuildRet = swapChainBuild.set_old_swapchain(mRenderData.rdVkbSwapchain).set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR).build();
+  auto swapChainBuildRet = swapChainBuild
+    .set_old_swapchain(mRenderData.rdVkbSwapchain)
+    .set_desired_present_mode(VK_PRESENT_MODE_FIFO_KHR)
+    .set_desired_format(surfaceFormat)
+    .build();
+
   if (!swapChainBuildRet) {
     Logger::log(1, "%s error: could not init swapchain\n", __FUNCTION__);
     return false;
@@ -658,11 +668,6 @@ bool VkRenderer::draw() {
     return false;
   }
 
-  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
-    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
-    return false;
-  }
-
   uint32_t imageIndex = 0;
   VkResult result = vkAcquireNextImageKHR(mRenderData.rdVkbDevice.device,
       mRenderData.rdVkbSwapchain.swapchain,
@@ -678,6 +683,11 @@ bool VkRenderer::draw() {
       Logger::log(1, "%s error: failed to acquire swapchain image. Error is '%i'\n", __FUNCTION__, result);
       return false;
     }
+  }
+
+  if (vkResetFences(mRenderData.rdVkbDevice.device, 1, &mRenderData.rdRenderFence) != VK_SUCCESS) {
+    Logger::log(1, "%s error:  fence reset failed\n", __FUNCTION__);
+    return false;
   }
 
   VkClearValue colorClearValue;


### PR DESCRIPTION
Disable GL_FRAMEBUFFER_SRGB on OpenGL, add surface parameter on Vulkan, and move ResetFence after acquiring the next swapchain image