### PR TITLE
Add vmaFlushAllocation() for Vulkan examples

### DIFF
--- a/chapter04/04_vulkan_ubo/vulkan/UniformBuffer.cpp
+++ b/chapter04/04_vulkan_ubo/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter05/05_vulkan_ui/vulkan/UniformBuffer.cpp
+++ b/chapter05/05_vulkan_ui/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter05/06_vulkan_ui_fps/vulkan/UniformBuffer.cpp
+++ b/chapter05/06_vulkan_ui_fps/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter05/07_vulkan_ui_timer/vulkan/UniformBuffer.cpp
+++ b/chapter05/07_vulkan_ui_timer/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter05/08_vulkan_ui_controls/vulkan/UniformBuffer.cpp
+++ b/chapter05/08_vulkan_ui_controls/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter06/03_vulkan_view/vulkan/UniformBuffer.cpp
+++ b/chapter06/03_vulkan_view/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter06/04_vulkan_movement/vulkan/UniformBuffer.cpp
+++ b/chapter06/04_vulkan_movement/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/07_vulkan_rotation/vulkan/UniformBuffer.cpp
+++ b/chapter07/07_vulkan_rotation/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/08_vulkan_quaternion/vulkan/UniformBuffer.cpp
+++ b/chapter07/08_vulkan_quaternion/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/09_vulkan_relative_rotation/vulkan/UniformBuffer.cpp
+++ b/chapter07/09_vulkan_relative_rotation/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/10_vulkan_slerp/vulkan/UniformBuffer.cpp
+++ b/chapter07/10_vulkan_slerp/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/11_vulkan_spline/vulkan/UniformBuffer.cpp
+++ b/chapter07/11_vulkan_spline/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter07/12_vulkan_quat_spline/vulkan/UniformBuffer.cpp
+++ b/chapter07/12_vulkan_quat_spline/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter08/02_vulkan_gltf_load/vulkan/UniformBuffer.cpp
+++ b/chapter08/02_vulkan_gltf_load/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter09/05_vulkan_gltf_bindpose/vulkan/UniformBuffer.cpp
+++ b/chapter09/05_vulkan_gltf_bindpose/vulkan/UniformBuffer.cpp
@@ -83,6 +83,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUploadMatrices matric
   vmaMapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc, &data);
   std::memcpy(data, &matrices, sizeof(VkUploadMatrices));
   vmaUnmapMemory(renderData.rdAllocator, renderData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, renderData.rdUboBufferAlloc, 0, sizeof(VkUploadMatrices));
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData) {

--- a/chapter09/06_vulkan_gltf_gpu_skinning/vulkan/UniformBuffer.cpp
+++ b/chapter09/06_vulkan_gltf_gpu_skinning/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter09/07_vulkan_gltf_ssbo/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter09/07_vulkan_gltf_ssbo/vulkan/ShaderStorageBuffer.cpp
@@ -96,6 +96,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter09/07_vulkan_gltf_ssbo/vulkan/UniformBuffer.cpp
+++ b/chapter09/07_vulkan_gltf_ssbo/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter09/08_vulkan_gltf_dual_quat/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter09/08_vulkan_gltf_dual_quat/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter09/08_vulkan_gltf_dual_quat/vulkan/UniformBuffer.cpp
+++ b/chapter09/08_vulkan_gltf_dual_quat/vulkan/UniformBuffer.cpp
@@ -97,6 +97,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter10/02_vulkan_animations/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter10/02_vulkan_animations/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter10/02_vulkan_animations/vulkan/UniformBuffer.cpp
+++ b/chapter10/02_vulkan_animations/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter11/04_vulkan_blending/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter11/04_vulkan_blending/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter11/04_vulkan_blending/vulkan/UniformBuffer.cpp
+++ b/chapter11/04_vulkan_blending/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter11/05_vulkan_crossblending/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter11/05_vulkan_crossblending/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter11/05_vulkan_crossblending/vulkan/UniformBuffer.cpp
+++ b/chapter11/05_vulkan_crossblending/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter11/06_vulkan_additive_blending/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter11/06_vulkan_additive_blending/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter11/06_vulkan_additive_blending/vulkan/UniformBuffer.cpp
+++ b/chapter11/06_vulkan_additive_blending/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter12/04_vulkan_combobox/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter12/04_vulkan_combobox/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter12/04_vulkan_combobox/vulkan/UniformBuffer.cpp
+++ b/chapter12/04_vulkan_combobox/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter12/05_vulkan_radiobutton/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter12/05_vulkan_radiobutton/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter12/05_vulkan_radiobutton/vulkan/UniformBuffer.cpp
+++ b/chapter12/05_vulkan_radiobutton/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter12/06_vulkan_plots/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter12/06_vulkan_plots/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter12/06_vulkan_plots/vulkan/UniformBuffer.cpp
+++ b/chapter12/06_vulkan_plots/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter13/03_vulkan_ccd/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter13/03_vulkan_ccd/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter13/03_vulkan_ccd/vulkan/UniformBuffer.cpp
+++ b/chapter13/03_vulkan_ccd/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter13/04_vulkan_fabrik/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter13/04_vulkan_fabrik/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter13/04_vulkan_fabrik/vulkan/UniformBuffer.cpp
+++ b/chapter13/04_vulkan_fabrik/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter14/05_vulkan_instances/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter14/05_vulkan_instances/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter14/05_vulkan_instances/vulkan/UniformBuffer.cpp
+++ b/chapter14/05_vulkan_instances/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter14/06_vulkan_multiple_models/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter14/06_vulkan_multiple_models/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter14/06_vulkan_multiple_models/vulkan/UniformBuffer.cpp
+++ b/chapter14/06_vulkan_multiple_models/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter14/07_vulkan_instanced_drawing/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter14/07_vulkan_instanced_drawing/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter14/07_vulkan_instanced_drawing/vulkan/UniformBuffer.cpp
+++ b/chapter14/07_vulkan_instanced_drawing/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter14/08_vulkan_tbo/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter14/08_vulkan_tbo/vulkan/ShaderStorageBuffer.cpp
@@ -95,6 +95,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +108,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter14/08_vulkan_tbo/vulkan/UniformBuffer.cpp
+++ b/chapter14/08_vulkan_tbo/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {

--- a/chapter15/02_vulkan_optimize/vulkan/ShaderStorageBuffer.cpp
+++ b/chapter15/02_vulkan_optimize/vulkan/ShaderStorageBuffer.cpp
@@ -19,6 +19,7 @@ bool ShaderStorageBuffer::init(VkRenderData& renderData, VkShaderStorageBufferDa
     return false;
   }
 
+
   VkDescriptorSetLayoutBinding ssboBind{};
   ssboBind.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
   ssboBind.binding = 0;
@@ -95,6 +96,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
@@ -107,6 +109,7 @@ void ShaderStorageBuffer::uploadData(VkRenderData &renderData,
   vmaMapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, &data);
   std::memcpy(data, matricesToUpload.data(), SSBOData.rdSsboBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, SSBOData.rdSsboBufferAlloc, 0, SSBOData.rdSsboBufferSize);
 }
 
 void ShaderStorageBuffer::cleanup(VkRenderData& renderData, VkShaderStorageBufferData &SSBOData) {

--- a/chapter15/02_vulkan_optimize/vulkan/UniformBuffer.cpp
+++ b/chapter15/02_vulkan_optimize/vulkan/UniformBuffer.cpp
@@ -96,6 +96,7 @@ void UniformBuffer::uploadData(VkRenderData &renderData, VkUniformBufferData &UB
     &data);
   std::memcpy(data, matricesToUpload.data(), UBOData.rdUniformBufferSize);
   vmaUnmapMemory(renderData.rdAllocator, UBOData.rdUboBufferAlloc);
+  vmaFlushAllocation(renderData.rdAllocator, UBOData.rdUboBufferAlloc, 0, UBOData.rdUniformBufferSize);
 }
 
 void UniformBuffer::cleanup(VkRenderData& renderData, VkUniformBufferData &UBOData) {


### PR DESCRIPTION
Flush allocation after VMA memory unmap, just in case memory is not HOST_COHERENT